### PR TITLE
touch: fix the appearance of the move indicator in the command menu

### DIFF
--- a/3rdparty/cs16client-extras/touch/cmd/my_menu-2-connection.cfg
+++ b/3rdparty/cs16client-extras/touch/cmd/my_menu-2-connection.cfg
@@ -16,12 +16,12 @@ set _menu_cmd_6 "rate"
 set _menu_f6 $rate
 
 set _menu_type_7 3
-set _menu_txt_7 "Update Rate; Incomming"
+set _menu_txt_7 "Update Rate; Incoming"
 set _menu_cmd_7 "cl_updaterate"
 set _menu_f7 $cl_updaterate
 
 set _menu_type_8 3
-set _menu_txt_8 "Update Rate; Outcomming"
+set _menu_txt_8 "Update Rate; Outcoming"
 set _menu_cmd_8 "cl_cmdrate"
 set _menu_f8 $cl_cmdrate
 

--- a/3rdparty/cs16client-extras/touch/customcmd.cfg
+++ b/3rdparty/cs16client-extras/touch/customcmd.cfg
@@ -1,7 +1,10 @@
 cmd_scripting 1
 //touch_setclientonly 1
 touch_set_stroke 1 156 77 20 200
-alias _erase_frame "touch_removebutton _menu_*; touch_setclientonly 0; unalias _erase_frame"
+if "$touch_move_indicator > 0"
+:set touch_indicator_value "$touch_move_indicator"
+:set touch_move_indicator 0
+alias _erase_frame "touch_removebutton _menu_*; touch_setclientonly 0; set touch_move_indicator $touch_indicator_value; unalias _erase_frame"
 alias _click_cnd "play media/launch_select1.wav; vibrate 30"
 alias _click_cnd_back "play media/launch_upmenu1.wav; vibrate 30"
 touch_addbutton "_menu_look" "" "_look" 0.5 0 1 1 0 0 0 0 6


### PR DESCRIPTION
Исправление появления индикатора движения в командном и бот меню.

При закрытии меню, возвращается прежнее значение ``touch_move_indicator``, и соответственно сам индикатор возвращается.