### PR TITLE
Switch YaPB to upstream repository

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,24 +10,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
       - name: Fetch YaPB Graphs from DB
         run: scripts/yapb_graph_dl.sh
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: 'temurin'
           cache: gradle
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v2
+        uses: android-actions/setup-android@v3
       - name: Build
         run: ./gradlew assembleDebug
       - name: Sign APK
-        uses: r0adkll/sign-android-release@v1
+        uses: noriban/sign-android-release@v5
         with:
           releaseDirectory: app/build/outputs/apk/debug
           signingKeyBase64: ${{ secrets.SIGNING_KEY }}
@@ -46,7 +46,7 @@ jobs:
   #   runs-on: ubuntu-latest
   #   steps:
   #     - name: Checkout sources
-  #       uses: actions/checkout@v3
+  #       uses: actions/checkout@v4
   #       with:
   #         fetch-depth: 0
   #         submodules: recursive
@@ -61,7 +61,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
@@ -101,7 +101,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
@@ -142,7 +142,7 @@ jobs:
     needs: [android, windows, linux]
     steps:
       - name: Fetch artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
       - name: Remove old release
         uses: dev-drprasad/delete-tag-and-release@v1.0
         with:
@@ -193,8 +193,8 @@ jobs:
       - name: Upload new release
         uses: svenstaro/upload-release-action@v2
         with:
-          repo_name: Velaron/cs16-client
-          repo_token: ${{ secrets.REPO_TOKEN }}
+          repo_name: ${{ env.GITHUB_REPOSITORY }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
           file_glob: true
           file: cs16-client*
           tag: continuous

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Build
         run: ./gradlew assembleDebug
       - name: Sign APK
-        uses: noriban/sign-android-release@v5
+        uses: r0adkll/sign-android-release@v1
         with:
           releaseDirectory: app/build/outputs/apk/debug
           signingKeyBase64: ${{ secrets.SIGNING_KEY }}
@@ -37,7 +37,7 @@ jobs:
         env:
           BUILD_TOOLS_VERSION: "34.0.0"
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: android
           path: app/build/outputs/apk/debug/app-debug-signed.apk
@@ -81,7 +81,7 @@ jobs:
       - name: Generate extras.pk3
         run: Compress-Archive -Path 3rdparty/cs16client-extras/* -Destination build/extras.pk3 -CompressionLevel NoCompression
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: win32-${{ matrix.arch }}
           path: |
@@ -125,7 +125,7 @@ jobs:
       - name: Generate extras.pk3
         run: zip -0 -r build/extras.pk3 3rdparty/cs16client-extras
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: linux-${{ matrix.arch }}
           path: |
@@ -144,12 +144,13 @@ jobs:
       - name: Fetch artifacts
         uses: actions/download-artifact@v4
       - name: Remove old release
-        uses: dev-drprasad/delete-tag-and-release@v1.0
+        uses: ClementTsang/delete-tag-and-release@v0.3.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: continuous
           delete_release: true
-          github_token: ${{ secrets.REPO_TOKEN }}
-          repo: Velaron/cs16-client
+          repo: ${{ env.GITHUB_REPOSITORY }}
       - name: Repackage binaries
         run: |
           mv android/app-debug-signed.apk cs16-client.apk

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "3rdparty/yapb"]
 	path = 3rdparty/yapb
-	url = https://github.com/Velaron/yapb
+	url = https://github.com/yapb/yapb
 [submodule "3rdparty/mainui_cpp"]
 	path = 3rdparty/mainui_cpp
 	url = https://github.com/Velaron/mainui_cpp


### PR DESCRIPTION
Due to all the changes from yours's android fork is now in upstream, i believe it's time to change submodule URL to primary upstream repo.

Also changed some GH actions to suit changes with node20 requirement.