### PR TITLE
Various fixes

### DIFF
--- a/cl_dll/GameStudioModelRenderer.cpp
+++ b/cl_dll/GameStudioModelRenderer.cpp
@@ -766,12 +766,6 @@ int CGameStudioModelRenderer::StudioDrawPlayer(int flags, entity_state_t *pplaye
 
 	m_pplayer = pplayer;
 
-	if( g_iUser1 == OBS_IN_EYE && g_iUser2 == pplayer->number )
-		return 0;
-
-	if( !g_iUser1 && !cam_thirdperson && gEngfuncs.pEventAPI->EV_IsLocal( pplayer->number - 1 ))
-		return 0;
-
 	if (m_bLocal && IEngineStudio.GetCurrentEntity() == gEngfuncs.GetLocalPlayer())
 		isLocalPlayer = true;
 

--- a/cl_dll/menu.cpp
+++ b/cl_dll/menu.cpp
@@ -80,8 +80,7 @@ int CHudMenu :: Draw( float flTime )
 	{
 		if ( m_flShutoffTime <= gHUD.m_flTime )
 		{  // times up, shutoff
-			m_fMenuDisplayed = 0;
-			m_iFlags &= ~HUD_DRAW;
+			UserCmd_OldStyleMenuClose();
 			return 1;
 		}
 	}
@@ -130,9 +129,7 @@ void CHudMenu :: SelectMenuItem( int menu_item )
 		sprintf( szbuf, "menuselect %d\n", menu_item );
 		ClientCmd( szbuf );
 
-		// remove the menu
-		m_fMenuDisplayed = 0;
-		m_iFlags &= ~HUD_DRAW;
+		UserCmd_OldStyleMenuClose();
 	}
 }
 
@@ -163,7 +160,6 @@ int CHudMenu :: MsgFunc_ShowMenu( const char *pszName, int iSize, void *pbuf )
 	{
 		m_fMenuDisplayed = 0; // no valid slots means that the menu should be turned off
 		m_iFlags &= ~HUD_DRAW;
-		ClientCmd("touch_removebutton _menu_*");
 		return 1;
 	}
 
@@ -239,7 +235,6 @@ int CHudMenu::MsgFunc_VGUIMenu( const char *pszName, int iSize, void *pbuf )
 
 int CHudMenu::MsgFunc_BuyClose(const char *pszName, int iSize, void *pbuf)
 {
-	UserCmd_OldStyleMenuClose();
 	gMobileAPI.pfnTouchRemoveButton("_menu_*");
 	return 1;
 }
@@ -334,9 +329,8 @@ void CHudMenu::ShowVGUIMenu( int menuType )
 		szCmd = "exec touch/numerical_menu.cfg";
 		break;
 	default:
-		szCmd = "touch_removebutton _menu_*"; // back to the default touch page
-		m_fMenuDisplayed = 0;
-		break;
+		UserCmd_OldStyleMenuClose();
+		return;
 	}
 
 	m_fMenuDisplayed = 1;


### PR DESCRIPTION
1. Always call removing _menu_* buttons when menu is closed. Just less annoying to use on PC with default settings.

2. This is actually interesting one. I suppose these checks were added by me trying to avoid drawing player, there were multiple bugs about it and I didn't found the real cause. I guess now that we have more bugfixed engine and better knowledge of the game, these checks can be removed. At least, they definitely shouldn't be here. Fixes https://github.com/FWGS/xash3d-fwgs/issues/1660