### PR TITLE
client: hud: scoreboard: fix NULL dereference

### DIFF
--- a/cl_dll/hud/scoreboard.cpp
+++ b/cl_dll/hud/scoreboard.cpp
@@ -397,7 +397,7 @@ int CHudScoreboard :: DrawPlayers( float list_slot, int nameoffset, const char *
 
 		if( cl_showplayerversion->value == 0.0f )
 		{
-			if ( stricmp( team, "SPECTATOR" ))
+			if( team && stricmp( team, "SPECTATOR" ))
 			{
 				// draw bomb( if player have the bomb )
 				if( g_PlayerExtraInfo[best_player].dead )


### PR DESCRIPTION
`team` might be NULL if `DrawPlayers` called with default argument