### PR TITLE
client: vgui_parser: fix invalid free()

### DIFF
--- a/cl_dll/vgui_parser.cpp
+++ b/cl_dll/vgui_parser.cpp
@@ -63,11 +63,11 @@ const char *Localize( const char *szStr )
 {
 	if( szStr )
 	{
+		if( *szStr == '#' )
+			szStr++;
+
 		char *str = strdup( szStr );
 		StripEndNewlineFromString( str );
-
-		if( *str == '#' )
-			str++;
 
 		int i = hashed_cmds.Find( str );
 


### PR DESCRIPTION
Pointer to allocated data has been lost if the first character was '#'.

Instead, do the same on the pointer to the original string.