### PR TITLE
client: fix bug when chat prompt overlaps with console history

### DIFF
--- a/cl_dll/cdll_int.cpp
+++ b/cl_dll/cdll_int.cpp
@@ -411,7 +411,6 @@ int DLLEXPORT HUD_MobilityInterface( mobile_engfuncs_t *mobileapi )
 
 extern "C" void DLLEXPORT HUD_ChatInputPosition( int *x, int *y )
 {
-	*x = *y = 0;
 }
 
 extern "C" int DLLEXPORT HUD_GetPlayerTeam(int iplayer)


### PR DESCRIPTION
This was probably added by mistake back when I added "F" export for cs16-client.

Nor hlsdk-xash3d, nor Valve's SDK, set any default value here.