### PR TITLE
build: macos arm build POC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,11 @@ set(EXTRAS_DIR "${CMAKE_CURRENT_BINARY_DIR}/extras")
 include(LibraryNaming)
 # include(ExternalProject)
 
+if(APPLE)
+	set(BUILD_SERVER OFF CACHE BOOL "Build menu library." FORCE)
+	set(BUILD_MAINUI OFF CACHE BOOL "Build server library." FORCE)
+endif()
+
 option(BUILD_CLIENT "Build client library." ON)
 option(BUILD_MAINUI "Build menu library." ON)
 option(BUILD_SERVER "Build server library." ON)

--- a/README.md
+++ b/README.md
@@ -55,3 +55,8 @@ cmake --build build --config Release
 ```
 ./gradlew assembleRelease
 ```
+### MacOS (client only)
+```
+cmake -S . -B build
+cmake --build build --config Release
+```

--- a/cl_dll/CMakeLists.txt
+++ b/cl_dll/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
 project(client)
 
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 set(CLIENT_LIB client)
 
 file(GLOB CS_CLIENT_SRC "*.cpp")

--- a/common/interface.cpp
+++ b/common/interface.cpp
@@ -10,6 +10,11 @@
 #include <stdio.h>
 #include "interface.h"
 
+#if !defined( _WIN32 )
+#include <dlfcn.h>
+#include <unistd.h>
+#endif
+
 #if XASH_PSVITA == 1
 #include <unistd.h>
 #define VRTLD_LIBDL_COMPAT


### PR DESCRIPTION
# 🧪 Proof of Concept: macOS ARM (Apple Silicon) Build Support

This PR introduces a **proof of concept** for building and running the CS16 client on **macOS ARM (Apple Silicon)**, in response to Issue #162. While this is an experimental implementation, it demonstrates that supporting macOS on Apple Silicon is technically feasible.

The goal here is to kickstart discussion and iteration on proper macOS support. Feedback, improvements, and corrections are warmly welcome!

---

## 🔧 Building Instructions

This process involves building the CS16 client and the [Xash3D-FWGS engine](https://github.com/FWGS/xash3d-fwgs), and then setting up game files using SteamCMD. Everything is bundled manually into a playable setup.

### 1. Set Up Project Workspace

```bash
mkdir -p ~/cs16-macos
```

### 2. Build the CS16 Client

#### a) Install dependencies

```bash
brew install cmake pkg-config clang
```

#### b) Clone the client repo (with `build/macos-arm` branch)

```bash
cd ~/cs16-macos
git clone --single-branch --branch build/macos-arm https://github.com/kenyerman/cs16-client-macos-arm --recursive
```

#### c) Build the client

```bash
cd cs16-client-macos-arm
cmake -S . -B build
cmake --build build --config Release
cmake --install ./build --prefix ./release
```

Output will be available in:
`~/cs16-macos/cs16-client-macos-arm/release`

---

### 3. Build the Engine (Xash3D-FWGS)

#### a) Clone the engine repo

```bash
cd ~/cs16-macos
git clone --recursive https://github.com/FWGS/xash3d-fwgs
```

#### b) Download SDL2

Download the latest SDL2 v2.x release from:
[https://github.com/libsdl-org/SDL/releases](https://github.com/libsdl-org/SDL/releases)

Mount the `.dmg`, then copy `SDL2.framework` to:
`~/cs16-macos/SDL2.Framework`

#### c) Build the engine

```bash
cd xash3d-fwgs
./waf configure --sdl2=~/cs16-macos/SDL2.Framework
./waf build
mkdir -p ~/cs16-macos/xash3d-install
./waf install --destdir=../xash3d-install
```

Engine files will be located at:
`~/cs16-macos/xash3d-install`

---

### 4. Get the Game Files (via SteamCMD)

#### a) Install SteamCMD

```bash
brew install steamcmd
```

#### b) Create a directory for the game

```bash
mkdir -p ~/cs16-macos/hl
```

#### c) Download Half-Life via SteamCMD

```bash
steamcmd

force_install_dir ./hl
login <YOUR_USERNAME>
@sSteamCmdForcePlatformType windows
app_update 10
quit
```

You should now have the base game files in `~/cs16-macos/hl`.
(If it fails, use `apps_installed` in SteamCMD to check the location and copy manually.)

---

### 5. Merge Everything

```bash
cd ~/cs16-macos
cp -r ./xash3d-install/* ./hl
cp -r ./cs16-client-macos-arm/release/* ./hl
```

---

### 6. Run the Mod 🎮

**Heads up:** The first launch on macOS may trigger security prompts. Start in **windowed** mode to avoid being stuck behind fullscreen SDL2 windows.

```bash
cd ~/cs16-macos/hl
./xash3d -windowed -game cstrike 
```

---

## 🙏 Acknowledgements

Thanks to the maintainers and contributors of this amazing project.
This is a first step toward expanding support for more platforms—Apple Silicon is here to stay, and it's exciting to see CS16 inching closer to native support!

My experience with C++ build systems is a bit rusty, so please let me know if anything can be improved or if I’ve accidentally broken something. I’m happy to iterate.

Cheers!
— @kenyerman