### PR TITLE
extras: fix shotgun descriptions in the buy menu

### DIFF
--- a/3rdparty/cs16client-extras/touch/buy_shotgun_ct.cfg
+++ b/3rdparty/cs16client-extras/touch/buy_shotgun_ct.cfg
@@ -84,24 +84,24 @@ touch_addbutton "_menu_frame_txt_data2_8" "#MUZZLE VELOCITY" "" 0.39 0.8 0.56 0.
 touch_addbutton "_menu_frame_txt_data2_9" "#MUZZLE ENERGY" "" 0.39 0.835556 0.56 0.871111 240 180 24 255 4
 
 touch_addbutton "_menu_frame_txt_desc1_1" "#: \$$_menu_money_item1" "" 0.56 0.551111 0.84 0.586667 240 180 24 255 4
-touch_addbutton "_menu_frame_txt_desc1_2" "#: FRANCE" "" 0.56 0.586667 0.84 0.622222 240 180 24 255 4
-touch_addbutton "_menu_frame_txt_desc1_3" "#: 5.56 NATO" "" 0.56 0.622222 0.84 0.657778 240 180 24 255 4
-touch_addbutton "_menu_frame_txt_desc1_4" "#: 25 ROUNDS" "" 0.56 0.657778 0.84 0.693333 240 180 24 255 4
-touch_addbutton "_menu_frame_txt_desc1_5" "#: 1100 RPM" "" 0.56 0.693333 0.84 0.728889 240 180 24 255 4
-touch_addbutton "_menu_frame_txt_desc1_6" "#: 3.40KG" "" 0.56 0.728889 0.84 0.764444 240 180 24 255 4
-touch_addbutton "_menu_frame_txt_desc1_7" "#: 4 GRAMS" "" 0.56 0.764444 0.84 0.8 240 180 24 255 4
-touch_addbutton "_menu_frame_txt_desc1_8" "#: 2212 FEET/SECOND" "" 0.56 0.8 0.84 0.835556 240 180 24 255 4
-touch_addbutton "_menu_frame_txt_desc1_9" "#: 1712 JOULES" "" 0.56 0.835556 0.84 0.871111 240 180 24 255 4
+touch_addbutton "_menu_frame_txt_desc1_2" "#: ITALY" "" 0.56 0.586667 0.84 0.622222 240 180 24 255 4
+touch_addbutton "_menu_frame_txt_desc1_3" "#: 12 GAUGE" "" 0.56 0.622222 0.84 0.657778 240 180 24 255 4
+touch_addbutton "_menu_frame_txt_desc1_4" "#: 8 ROUNDS" "" 0.56 0.657778 0.84 0.693333 240 180 24 255 4
+touch_addbutton "_menu_frame_txt_desc1_5" "#: N/A" "" 0.56 0.693333 0.84 0.728889 240 180 24 255 4
+touch_addbutton "_menu_frame_txt_desc1_6" "#: 3.5KG" "" 0.56 0.728889 0.84 0.764444 240 180 24 255 4
+touch_addbutton "_menu_frame_txt_desc1_7" "#: 3.8 GRAMS" "" 0.56 0.764444 0.84 0.8 240 180 24 255 4
+touch_addbutton "_menu_frame_txt_desc1_8" "#: 1250 FEET/SECOND" "" 0.56 0.8 0.84 0.835556 240 180 24 255 4
+touch_addbutton "_menu_frame_txt_desc1_9" "#: 2429 JOULES" "" 0.56 0.835556 0.84 0.871111 240 180 24 255 4
 
 touch_addbutton "_menu_frame_txt_desc2_1" "#: \$$_menu_money_item2" "" 0.56 0.551111 0.84 0.586667 240 180 24 255 4
-touch_addbutton "_menu_frame_txt_desc2_2" "#: AUSTRIA" "" 0.56 0.586667 0.84 0.622222 240 180 24 255 4
-touch_addbutton "_menu_frame_txt_desc2_3" "#: 7.62 NATO" "" 0.56 0.622222 0.84 0.657778 240 180 24 255 4
-touch_addbutton "_menu_frame_txt_desc2_4" "#: 10 ROUNDS" "" 0.56 0.657778 0.84 0.693333 240 180 24 255 4
-touch_addbutton "_menu_frame_txt_desc2_5" "#: N/A" "" 0.56 0.693333 0.84 0.728889 240 180 24 255 4
-touch_addbutton "_menu_frame_txt_desc2_6" "#: 3.3KG" "" 0.56 0.728889 0.84 0.764444 240 180 24 255 4
-touch_addbutton "_menu_frame_txt_desc2_7" "#: 8 GRAMS" "" 0.56 0.764444 0.84 0.8 240 180 24 255 4
-touch_addbutton "_menu_frame_txt_desc2_8" "#: 2800 FEET/SECOND" "" 0.56 0.8 0.84 0.835556 240 180 24 255 4
-touch_addbutton "_menu_frame_txt_desc2_9" "#: 2200 JOULES" "" 0.56 0.835556 0.84 0.871111 240 180 24 255 4
+touch_addbutton "_menu_frame_txt_desc2_2" "#: ITALY" "" 0.56 0.586667 0.84 0.622222 240 180 24 255 4
+touch_addbutton "_menu_frame_txt_desc2_3" "#: 12 GAUGE" "" 0.56 0.622222 0.84 0.657778 240 180 24 255 4
+touch_addbutton "_menu_frame_txt_desc2_4" "#: 7 ROUNDS" "" 0.56 0.657778 0.84 0.693333 240 180 24 255 4
+touch_addbutton "_menu_frame_txt_desc2_5" "#: 400 RPM" "" 0.56 0.693333 0.84 0.728889 240 180 24 255 4
+touch_addbutton "_menu_frame_txt_desc2_6" "#: 4KG" "" 0.56 0.728889 0.84 0.764444 240 180 24 255 4
+touch_addbutton "_menu_frame_txt_desc2_7" "#: 3.8 GRAMS/PELLET" "" 0.56 0.764444 0.84 0.8 240 180 24 255 4
+touch_addbutton "_menu_frame_txt_desc2_8" "#: 1250 FEET/SECOND" "" 0.56 0.8 0.84 0.835556 240 180 24 255 4
+touch_addbutton "_menu_frame_txt_desc2_9" "#: 2429 JOULES" "" 0.56 0.835556 0.84 0.871111 240 180 24 255 4
 
 //touch_addbutton "_menu_frame_txt_desc3_1" "#: " "" 0.56 0.551111 0.84 0.586667 240 180 24 255 4
 //touch_addbutton "_menu_frame_txt_desc3_2" "#: " "" 0.56 0.586667 0.84 0.622222 240 180 24 255 4

--- a/3rdparty/cs16client-extras/touch/buy_shotgun_t.cfg
+++ b/3rdparty/cs16client-extras/touch/buy_shotgun_t.cfg
@@ -84,24 +84,24 @@ touch_addbutton "_menu_frame_txt_data2_8" "#MUZZLE VELOCITY" "" 0.39 0.8 0.56 0.
 touch_addbutton "_menu_frame_txt_data2_9" "#MUZZLE ENERGY" "" 0.39 0.835556 0.56 0.871111 240 180 24 255 4
 
 touch_addbutton "_menu_frame_txt_desc1_1" "#: \$$_menu_money_item1" "" 0.56 0.551111 0.84 0.586667 240 180 24 255 4
-touch_addbutton "_menu_frame_txt_desc1_2" "#: FRANCE" "" 0.56 0.586667 0.84 0.622222 240 180 24 255 4
-touch_addbutton "_menu_frame_txt_desc1_3" "#: 5.56 NATO" "" 0.56 0.622222 0.84 0.657778 240 180 24 255 4
-touch_addbutton "_menu_frame_txt_desc1_4" "#: 25 ROUNDS" "" 0.56 0.657778 0.84 0.693333 240 180 24 255 4
-touch_addbutton "_menu_frame_txt_desc1_5" "#: 1100 RPM" "" 0.56 0.693333 0.84 0.728889 240 180 24 255 4
-touch_addbutton "_menu_frame_txt_desc1_6" "#: 3.40KG" "" 0.56 0.728889 0.84 0.764444 240 180 24 255 4
-touch_addbutton "_menu_frame_txt_desc1_7" "#: 4 GRAMS" "" 0.56 0.764444 0.84 0.8 240 180 24 255 4
-touch_addbutton "_menu_frame_txt_desc1_8" "#: 2212 FEET/SECOND" "" 0.56 0.8 0.84 0.835556 240 180 24 255 4
-touch_addbutton "_menu_frame_txt_desc1_9" "#: 1712 JOULES" "" 0.56 0.835556 0.84 0.871111 240 180 24 255 4
+touch_addbutton "_menu_frame_txt_desc1_2" "#: ITALY" "" 0.56 0.586667 0.84 0.622222 240 180 24 255 4
+touch_addbutton "_menu_frame_txt_desc1_3" "#: 12 GAUGE" "" 0.56 0.622222 0.84 0.657778 240 180 24 255 4
+touch_addbutton "_menu_frame_txt_desc1_4" "#: 8 ROUNDS" "" 0.56 0.657778 0.84 0.693333 240 180 24 255 4
+touch_addbutton "_menu_frame_txt_desc1_5" "#: N/A" "" 0.56 0.693333 0.84 0.728889 240 180 24 255 4
+touch_addbutton "_menu_frame_txt_desc1_6" "#: 3.5KG" "" 0.56 0.728889 0.84 0.764444 240 180 24 255 4
+touch_addbutton "_menu_frame_txt_desc1_7" "#: 3.8 GRAMS" "" 0.56 0.764444 0.84 0.8 240 180 24 255 4
+touch_addbutton "_menu_frame_txt_desc1_8" "#: 1250 FEET/SECOND" "" 0.56 0.8 0.84 0.835556 240 180 24 255 4
+touch_addbutton "_menu_frame_txt_desc1_9" "#: 2429 JOULES" "" 0.56 0.835556 0.84 0.871111 240 180 24 255 4
 
 touch_addbutton "_menu_frame_txt_desc2_1" "#: \$$_menu_money_item2" "" 0.56 0.551111 0.84 0.586667 240 180 24 255 4
-touch_addbutton "_menu_frame_txt_desc2_2" "#: AUSTRIA" "" 0.56 0.586667 0.84 0.622222 240 180 24 255 4
-touch_addbutton "_menu_frame_txt_desc2_3" "#: 7.62 NATO" "" 0.56 0.622222 0.84 0.657778 240 180 24 255 4
-touch_addbutton "_menu_frame_txt_desc2_4" "#: 10 ROUNDS" "" 0.56 0.657778 0.84 0.693333 240 180 24 255 4
-touch_addbutton "_menu_frame_txt_desc2_5" "#: N/A" "" 0.56 0.693333 0.84 0.728889 240 180 24 255 4
-touch_addbutton "_menu_frame_txt_desc2_6" "#: 3.3KG" "" 0.56 0.728889 0.84 0.764444 240 180 24 255 4
-touch_addbutton "_menu_frame_txt_desc2_7" "#: 8 GRAMS" "" 0.56 0.764444 0.84 0.8 240 180 24 255 4
-touch_addbutton "_menu_frame_txt_desc2_8" "#: 2800 FEET/SECOND" "" 0.56 0.8 0.84 0.835556 240 180 24 255 4
-touch_addbutton "_menu_frame_txt_desc2_9" "#: 2200 JOULES" "" 0.56 0.835556 0.84 0.871111 240 180 24 255 4
+touch_addbutton "_menu_frame_txt_desc2_2" "#: ITALY" "" 0.56 0.586667 0.84 0.622222 240 180 24 255 4
+touch_addbutton "_menu_frame_txt_desc2_3" "#: 12 GAUGE" "" 0.56 0.622222 0.84 0.657778 240 180 24 255 4
+touch_addbutton "_menu_frame_txt_desc2_4" "#: 7 ROUNDS" "" 0.56 0.657778 0.84 0.693333 240 180 24 255 4
+touch_addbutton "_menu_frame_txt_desc2_5" "#: 400 RPM" "" 0.56 0.693333 0.84 0.728889 240 180 24 255 4
+touch_addbutton "_menu_frame_txt_desc2_6" "#: 4KG" "" 0.56 0.728889 0.84 0.764444 240 180 24 255 4
+touch_addbutton "_menu_frame_txt_desc2_7" "#: 3.8 GRAMS/PELLET" "" 0.56 0.764444 0.84 0.8 240 180 24 255 4
+touch_addbutton "_menu_frame_txt_desc2_8" "#: 1250 FEET/SECOND" "" 0.56 0.8 0.84 0.835556 240 180 24 255 4
+touch_addbutton "_menu_frame_txt_desc2_9" "#: 2429 JOULES" "" 0.56 0.835556 0.84 0.871111 240 180 24 255 4
 
 //touch_addbutton "_menu_frame_txt_desc3_1" "#: " "" 0.56 0.551111 0.84 0.586667 240 180 24 255 4
 //touch_addbutton "_menu_frame_txt_desc3_2" "#: " "" 0.56 0.586667 0.84 0.622222 240 180 24 255 4


### PR DESCRIPTION
Use proper shotgun descriptions instead of copypasted rifle descriptions.