### PR TITLE
killers health bug fix

### DIFF
--- a/cl_dll/hud.h
+++ b/cl_dll/hud.h
@@ -412,6 +412,20 @@ protected:
 		MAX_STATUSBAR_LINES = 2,
 	};
 
+	enum {
+		SBAR_TARGETTYPE_TEAMMATE = 1,
+		SBAR_TARGETTYPE_ENEMY,
+		SBAR_TARGETTYPE_HOSTAGE,
+	};
+
+	enum sbar_data
+	{
+		SBAR_ID_TARGETTYPE = 1,
+		SBAR_ID_TARGETNAME,
+		SBAR_ID_TARGETHEALTH,
+		SBAR_END
+	};
+
 	char m_szStatusText[MAX_STATUSBAR_LINES][MAX_STATUSTEXT_LENGTH];  // a text string describing how the status bar is to be drawn
 	char m_szStatusBar[MAX_STATUSBAR_LINES][MAX_STATUSTEXT_LENGTH];	// the constructed bar that is drawn
 	int m_iStatusValues[MAX_STATUSBAR_VALUES];  // an array of values for use in the status bar

--- a/cl_dll/statusbar.cpp
+++ b/cl_dll/statusbar.cpp
@@ -298,6 +298,12 @@ int CHudStatusBar :: MsgFunc_StatusValue( const char *pszName, int iSize, void *
 	m_iStatusValues[index] = reader.ReadShort();
 	m_iFlags |= HUD_DRAW;  // we have status text, so turn on the status bar
 
+	if (index == SBAR_ID_TARGETHEALTH && m_iStatusValues[SBAR_ID_TARGETTYPE] != SBAR_TARGETTYPE_HOSTAGE)//killers health
+	{
+		int entindex = m_iStatusValues[SBAR_ID_TARGETNAME];
+		g_PlayerExtraInfo[entindex].health = m_iStatusValues[SBAR_ID_TARGETHEALTH];
+	}
+	
 	m_bReparseString = TRUE;
 	
 	return 1;


### PR DESCRIPTION
Исправление бага когда при переходе в режим наблюдателя после смерти игрока, здоровье убившего игрока показывается как 0 hp