### PR TITLE
fix: restore touch move indicator after closing menus

### DIFF
--- a/3rdparty/cs16client-extras/touch/customcmd.cfg
+++ b/3rdparty/cs16client-extras/touch/customcmd.cfg
@@ -19,7 +19,11 @@ if $ui_language = russian	// Russian
 :set _menu_txt_exit "Выход"
 
 //	Cvars
-set touch_indicator_value "$touch_move_indicator" ;if "$touch_move_indicator > 0";:set touch_move_indicator 0
+if $_menu_opened <= 0
+:set touch_indicator_value "$touch_move_indicator"
+set _menu_opened 1
+if "$touch_move_indicator > 0"
+:set touch_move_indicator 0
 set _menu_stroke 1 156 77 20 200 ;touch_set_stroke $_menu_stroke
 set _menu_sel_bg "156 77 20 180"
 set _menu_bg "0 0 0 180"
@@ -30,7 +34,7 @@ set _menu_click_cnd media/launch_select1.wav
 set _menu_click_cnd_back media/launch_upmenu1.wav
 set _menu_vibrate_value 30
 //	Alias commands
-alias _erase_frame "touch_removebutton _menu_*; touch_setclientonly 0; set touch_move_indicator $touch_indicator_value; unalias _erase_frame"
+alias _erase_frame "touch_removebutton _menu_*; touch_setclientonly 0; set touch_move_indicator $touch_indicator_value; set _menu_opened 0; unalias _erase_frame"
 alias _reset_menu "touch_removebutton _menu_*; touch_setclientonly 0"
 alias _click_cnd "play $_menu_click_cnd ; vibrate $_menu_vibrate_value"
 alias _click_cnd_back "play $_menu_click_cnd_back ; vibrate $_menu_vibrate_value"
@@ -39,9 +43,9 @@ alias _closemenu_3 "touch_removebutton _menu_*_my_menu-3-*; touch_removebutton _
 alias _closemenu_4 "touch_removebutton _menu_*_my_menu-4-*; touch_removebutton _menu_*_my_menu-5-*; alias _closemenu_4 \"\""
 alias _closemenu_5 "touch_removebutton _menu_*_my_menu-5-*; alias _closemenu_5 \"\""
 //	Movement buttons
-if $menu_move_enable >= 1 // Enable/Disable _menu_move when value=1 or hinger
+if $menu_move_enable >= 1 // Enable/Disable _menu_move when value=1 or higher
 :touch_addbutton "_menu_move" "" "_move" 0 0.1 0.5 1 0 0 0 0 6
-if $menu_look_enable >= 1 // Enable/Disable _menu_look when value=1 or hinger
+if $menu_look_enable >= 1 // Enable/Disable _menu_look when value=1 or higher
 :touch_addbutton "_menu_look" "" "_look" 0.5 0 1 1 0 0 0 0 6
 //	Coordinates and closemenu for each level
 if $_menu_level = 1

--- a/3rdparty/cs16client-extras/userconfig.d/touch_defalias.cfg
+++ b/3rdparty/cs16client-extras/userconfig.d/touch_defalias.cfg
@@ -34,3 +34,4 @@ alias scoreboard "exec touch/scoreboard.cfg"
 // SET CVARS FOR MENU
 set enable_controls "0"
 set bot_quota_value "9"
+set _menu_opened "0"


### PR DESCRIPTION
Fixes: https://github.com/Velaron/cs16-client/issues/226