### PR TITLE
fix: strip indices in Condition Zero radio commands

### DIFF
--- a/cl_dll/text_message.cpp
+++ b/cl_dll/text_message.cpp
@@ -242,6 +242,7 @@ int CHudTextMessage::MsgFunc_TextMsg( const char *pszName, int iSize, void *pbuf
 
 	case HUD_PRINTRADIO:
 		psz[0] = 2;
+		Localize_StripIndices( szBuf[1] );
 		snprintf( psz + 1, MAX_TEXTMSG_STRING-1, szBuf[1], szBuf[2], szBuf[3], szBuf[4] );
 
 		clientIdx = atoi( szBuf[0] );


### PR DESCRIPTION
## Before
<img width="370" height="23" alt="image" src="https://github.com/user-attachments/assets/c1918f8e-62f5-4b58-8a9e-e11aa83c5f9f" />

## After
<img width="346" height="22" alt="image" src="https://github.com/user-attachments/assets/e190ed62-1062-47c9-9b99-d207877d1fe9" />