### PR TITLE
Load Counter-Strike 1.6 localization in Counter-Strike: Condition Zero

### DIFF
--- a/cl_dll/vgui_parser.cpp
+++ b/cl_dll/vgui_parser.cpp
@@ -247,6 +247,10 @@ static void Localize_InitLanguage( const char *language )
 	if( strcmp( gamedir, "mainui" ))
 		Localize_AddToDictionary( "mainui", language );
 
+	// if gamedir is czero, also load cstrike strings
+	if ( strcmp( gamedir, "czero" ) == 0 )
+		Localize_AddToDictionary( "cstrike", language );
+	
 	// mod strings override default ones
 	Localize_AddToDictionary( gamedir,  language );
 }


### PR DESCRIPTION
For example, this fixes unlocalized strings in the scoreboard.

## Before
<img width="1846" height="101" alt="image" src="https://github.com/user-attachments/assets/6867fa45-c408-4cfb-af35-33cfc414c763" />

## After
<img width="1834" height="114" alt="image" src="https://github.com/user-attachments/assets/864401ad-1775-44ab-905d-4e264a466e85" />
