### PR TITLE
Fix wrong positioning of entity marks in overview on screens with an aspect ratio different from 4:3

### DIFF
--- a/cl_dll/hud_spectator.cpp
+++ b/cl_dll/hud_spectator.cpp
@@ -1223,7 +1223,7 @@ void CHudSpectator::DrawOverviewLayer()
 		yTiles = 6;
 	}
 
-	screenaspect = ScreenWidth/ScreenHeight;
+	screenaspect = 4.0f/3.0f;
 
 
 	xs = m_OverviewData.origin[0];


### PR DESCRIPTION
Fixes: https://github.com/Velaron/cs16-client/issues/31