### PR TITLE
fix null pointer dereference

### DIFF
--- a/game_shared/voice_status_hud.cpp
+++ b/game_shared/voice_status_hud.cpp
@@ -385,7 +385,8 @@ void CVoiceStatusHud::UpdateSpeakerStatus( int entindex, bool bTalking )
 				// If we don't have a label for this guy yet, then create one.
 				if ( !pLabel )
 				{
-					if ( pLabel = GetFreeVoiceLabel() )
+					pLabel = GetFreeVoiceLabel(); 
+					if ( pLabel )
 					{
 						// Get the name from the engine.
 						hud_player_info_t info;


### PR DESCRIPTION
line 388 was using a single assignment operator opposed to a comparison operator.
this made it so that pLabel was never initialized, leaving m_playerName as null.
