### PR TITLE
Introduce the ``cl_show_scoreboard_on_death`` cvar to toggle scoreboard display upon player death.

### DIFF
--- a/cl_dll/hud.h
+++ b/cl_dll/hud.h
@@ -388,6 +388,7 @@ private:
 	bool m_bDrawStroke;
 	cvar_t *cl_showpacketloss;
 	cvar_t *cl_showplayerversion;
+	cvar_t *cl_show_scoreboard_on_death;
 };
 
 //

--- a/cl_dll/hud/scoreboard.cpp
+++ b/cl_dll/hud/scoreboard.cpp
@@ -107,6 +107,7 @@ int CHudScoreboard :: Init( void )
 
 	cl_showpacketloss = CVAR_CREATE( "cl_showpacketloss", "0", FCVAR_ARCHIVE );
 	cl_showplayerversion = CVAR_CREATE( "cl_showplayerversion", "0", 0 );
+	cl_show_scoreboard_on_death = CVAR_CREATE( "cl_show_scoreboard_on_death", "0", FCVAR_ARCHIVE );
 
 	return 1;
 }
@@ -149,7 +150,10 @@ bool CHudScoreboard :: ShouldDrawScoreboard() const
 	if( m_bForceDraw )
 		return true;
 
-	if( m_bShowscoresHeld || gHUD.m_Health.m_iHealth <= 0 || gHUD.m_iIntermission )
+	if( m_bShowscoresHeld || gHUD.m_iIntermission )
+		return true;
+
+	if( cl_show_scoreboard_on_death && cl_show_scoreboard_on_death->value && gHUD.m_Health.m_iHealth <= 0 )
 		return true;
 
 	return false;

--- a/cl_dll/input.cpp
+++ b/cl_dll/input.cpp
@@ -845,7 +845,7 @@ int CL_ButtonBits( int bResetState )
 		bits |= IN_SCORE;
 	}
 
-	// Dead or in intermission? Shore scoreboard, too
+	// Intermission? Show scoreboard too
 	if( gHUD.m_Scoreboard.ShouldDrawScoreboard( ))
 	{
 		bits |= IN_SCORE;


### PR DESCRIPTION
Disabled by default to match the original CS 1.6 behavior
Related to: https://github.com/Velaron/cs16-client/issues/291