### PR TITLE
Move spectator GUI in draw order to prevent chat overlap

### DIFF
--- a/cl_dll/hud.cpp
+++ b/cl_dll/hud.cpp
@@ -358,10 +358,6 @@ void CHud :: Init( void )
 	m_SniperScope.Init();
 	m_NVG.Init();
 
-	// Spectator GUI is not need in singleplayer czeror
-	if( GetGameType() != GAME_CZERODS )
-		m_SpectatorGui.Init();
-
 	// Game HUD things
 	m_Ammo.Init();
 	m_Health.Init();
@@ -389,6 +385,11 @@ void CHud :: Init( void )
 	// all things that have own background and must be drawn last
 	m_ProgressBar.Init();
 	m_Menu.Init();
+
+	// Spectator GUI is not need in singleplayer czeror
+	if( GetGameType() != GAME_CZERODS )
+		m_SpectatorGui.Init();
+
 	m_Scoreboard.Init();
 
 	GetClientVoice()->Init( &g_VoiceStatusHelper );


### PR DESCRIPTION
## Before
<img width="1440" height="900" alt="as_highrise_0000" src="https://github.com/user-attachments/assets/98f0af09-11b2-4419-b442-a17743fee10a" />

## After
<img width="1440" height="900" alt="as_highrise_0001" src="https://github.com/user-attachments/assets/0a94e650-3bb9-4921-989b-c419cd958d25" />