### PR TITLE
Add player location to voice HUD for Condition Zero

### DIFF
--- a/cl_dll/hud.cpp
+++ b/cl_dll/hud.cpp
@@ -94,6 +94,19 @@ public:
 	{
 		return !gHUD.m_Scoreboard.m_bForceDraw && !gHUD.m_Scoreboard.m_bShowscoresHeld;
 	}
+
+	const char *GetPlayerLocation( int entindex ) override
+	{
+		if ( gHUD.GetGameType() == GAME_CZERO )
+		{
+			if ( entindex >= 1 && entindex <= MAX_PLAYERS )
+			{
+				return g_PlayerExtraInfo[entindex].location;
+			}
+		}
+
+		return "";
+	}
 };
 static CCStrikeVoiceStatusHelper g_VoiceStatusHelper;
 

--- a/game_shared/voice_status_hud.cpp
+++ b/game_shared/voice_status_hud.cpp
@@ -43,6 +43,8 @@
 //
 // #include <vgui/ILocalize.h>
 
+#include "utlstring.h"
+
 #include "triangleapi.h"
 #include "draw_util.h"
 
@@ -95,9 +97,8 @@ void CVoiceLabel::SetLocation( const char *location )
 		if ( !m_locationString )
 		{
 			// m_locationString = CloneWString( newLocation );
-			m_locationString = new char[sizeof( newLocation )];
-			strncpy( m_locationString, newLocation, sizeof( m_locationString ) );
-			// m_locationString[sizeof( m_locationString ) - 1] = '\0';
+			m_locationString = new char[strlen( newLocation ) + 1];
+			strcpy( m_locationString, newLocation );
 			RebuildLabelText();
 		}
 	}
@@ -156,16 +157,46 @@ void CVoiceLabel::RebuildLabelText()
 		// localize()->ConvertANSIToUnicode( m_playerName, wsPlayer, sizeof( wsPlayer ) );
 
 		// const wchar_t *formatStr = L"%ls   ";
-		const char *formatStr = "%s   ";
+		const char *locStr = Localize( "#Voice_Location" );
+
 		if ( m_locationString )
 		{
-			// formatStr = localize()->Find( "#Voice_Location" );
-			formatStr = Localize( "#Voice_Location" );
-			if ( !strcmp( formatStr, "#Voice_Location") )
-				formatStr = "%ls/%ls   ";
+			if ( !strcmp( locStr, "#Voice_Location" ) )
+			{
+				snprintf( buf, BufLen, "%s @ %s   ", m_playerName, m_locationString );
+			}
+			else
+			{
+				const char *tokens[2] = { m_playerName, m_locationString };
+				int tokenIdx = 0;
+
+				CUtlString result;
+				for ( const char *src = locStr; *src; )
+				{
+					if ( src[0] == '%' && src[1] == 's' && tokenIdx < 2 )
+					{
+						result += tokens[tokenIdx++];
+						src += 2;
+					}
+					else if ( src[0] == '%' && src[1] != '\0' && src[2] == 's' && tokenIdx < 2 )
+					{
+						result += tokens[tokenIdx++];
+						src += 3;
+					}
+					else
+					{
+						result.AppendChar( *src++ );
+					}
+				}
+				strncpy( buf, result.String(), BufLen - 1 );
+				buf[BufLen - 1] = '\0';
+			}
+		}
+		else
+		{
+			snprintf( buf, BufLen, "%s   ", m_playerName );
 		}
 		// _snwprintf( buf, BufLen, formatStr, wsPlayer, m_locationString );
-		snprintf( buf, BufLen, formatStr, m_playerName, m_locationString );
 	}
 	// /m_pLabel->SetText( buf );
 	strncpy( m_buf, buf, sizeof( m_buf ) );

--- a/game_shared/voice_status_hud.h
+++ b/game_shared/voice_status_hud.h
@@ -63,7 +63,7 @@ public:
 	void GetContentSize( int &wide, int &tall )
 	{
 		// m_pLabel->GetContentSize( wide, tall );
-		wide = DrawUtils::HudStringLen( m_playerName ) + 8;
+		wide = DrawUtils::HudStringLen( m_buf );
 
 		tall = gHUD.GetCharHeight();
 


### PR DESCRIPTION
Replaced a buggy `sizeof(newLocation)` calculation in `CVoiceLabel::SetLocation` with correct string length calculation using `strlen() + 1` and copying via `strcpy`. 
This prevents location names from being truncated to 4-8 characters.

Adjusted `GetContentSize` by replacing `(m_playerName) + 8` with `(m_buf)`  so the background box spans the full string (name + location), and removed the extra 8 pixels to reduce empty space on the right.

The official localization files use `%ls` (`wchar_t`). 
Since regular strings (`char*`) are passed, the text would disappear due to a type mismatch. 
As a result, code was added to replace `%ls` with `%s`, ensuring player and location names display correctly.