### PR TITLE
Prevent location from appearing in voice HUD on location change during voice chat in CS 1.6

### DIFF
--- a/cl_dll/hud/radar.cpp
+++ b/cl_dll/hud/radar.cpp
@@ -575,6 +575,9 @@ int CHudRadar::MsgFunc_HostageK(const char *pszName, int iSize, void *pbuf)
 
 int CHudRadar::MsgFunc_Location(const char *pszName, int iSize, void *pbuf)
 {
+	if ( gHUD.GetGameType() != GAME_CZERO )
+		return 0;
+
 	BufferReader reader( pszName, pbuf, iSize );
 
 	int player = reader.ReadByte();


### PR DESCRIPTION
Fixed an issue where location info appeared in the voice HUD on location change during voice chat.
Previously, this worked correctly only for ZBot, while other players/bots showed garbage like ``%hs @ PlayerName``.