### PR TITLE
Fix bot map analysis progress bar starting at 35% instead of 0%

### DIFF
--- a/cl_dll/hud/timer.cpp
+++ b/cl_dll/hud/timer.cpp
@@ -231,8 +231,10 @@ int CHudProgressBar::MsgFunc_BotProgress(const char *pszName, int iSize, void *p
 	int flag = reader.ReadByte();
 	switch( flag )
 	{
-	case UPDATE_BOTPROGRESS:
 	case CREATE_BOTPROGRESS:
+		m_fPercent = 0.0f;
+		break;
+	case UPDATE_BOTPROGRESS:
 		fNewPercent = (float)reader.ReadByte() / 100.0f;
 		// cs behavior:
 		// just don't decrease percent values


### PR DESCRIPTION
The reason was that the server sends the CREATE_BOTPROGRESS message without a percent byte (only flag + title string), but the client was trying to read a percent byte, taking the first character of the title string.