### PR TITLE
client: remove gametype check from PlayerLocation

### DIFF
--- a/cl_dll/hud.cpp
+++ b/cl_dll/hud.cpp
@@ -97,12 +97,9 @@ public:
 
 	const char *GetPlayerLocation( int entindex ) override
 	{
-		if ( gHUD.GetGameType() == GAME_CZERO )
+		if ( entindex >= 1 && entindex <= MAX_PLAYERS )
 		{
-			if ( entindex >= 1 && entindex <= MAX_PLAYERS )
-			{
-				return g_PlayerExtraInfo[entindex].location;
-			}
+			return g_PlayerExtraInfo[entindex].location;
 		}
 
 		return "";

--- a/cl_dll/hud/radar.cpp
+++ b/cl_dll/hud/radar.cpp
@@ -376,8 +376,7 @@ int CHudRadar::Draw(float flTime)
 		}
 	}
 
-	if( gHUD.GetGameType() == GAME_CZERO )
-		DrawPlayerLocation( ( m_hRadarOpaque.rect.Height() ) + 10 );
+	DrawPlayerLocation( ( m_hRadarOpaque.rect.Height() ) + 10 );
 
 	return 0;
 }
@@ -390,12 +389,17 @@ void CHudRadar::DrawPlayerLocation( int y )
 		// Localize the location string
 		const char *szLocalizedLocation = Localize( szLocation );
 
+		// don't draw unlocalized location
+		if( szLocalizedLocation[0] == '#' )
+			return;
+
 		int x = (m_hRadarOpaque.rect.Width()) / 2;
 		int len = DrawUtils::ConsoleStringLen( szLocalizedLocation );
 
 		x = x - len / 2;
 		if( x < 0 ) x = 0;
 
+		DrawUtils::SetConsoleTextColor( g_ColorGreen[0], g_ColorGreen[1], g_ColorGreen[2] );
 		DrawUtils::DrawConsoleString( x, y, szLocalizedLocation );
 	}
 }
@@ -576,9 +580,6 @@ int CHudRadar::MsgFunc_HostageK(const char *pszName, int iSize, void *pbuf)
 
 int CHudRadar::MsgFunc_Location(const char *pszName, int iSize, void *pbuf)
 {
-	if ( gHUD.GetGameType() != GAME_CZERO )
-		return 0;
-
 	BufferReader reader( pszName, pbuf, iSize );
 
 	int player = reader.ReadByte();


### PR DESCRIPTION
In original client.dll DrawPlayerLocation is drawn only when location from MsgFunc_Location can be localized.
This mean that if someone enabled zBot, using Condition Zero navigation and localization file then DrawPlayerLocation is drawn like in Condition Zero.

