### PR TITLE
Location parser fix

### DIFF
--- a/cl_dll/vgui_parser.cpp
+++ b/cl_dll/vgui_parser.cpp
@@ -235,17 +235,9 @@ static void Localize_InitLanguage( const char *language )
 {
 	const char *gamedir = gEngfuncs.pfnGetGameDirectory();
 
-	// if gamedir isn't gameui, then load standard gameui strings
-	if( strcmp( gamedir, "gameui" ))
-		Localize_AddToDictionary( "gameui", language );
-
 	// if gamedir isn't valve, then load standard HL1 strings
 	if( strcmp( gamedir, "valve" ))
 		Localize_AddToDictionary( "valve",  language );
-
-	// if gamedir isn't mainui, then load standard mainui strings
-	if( strcmp( gamedir, "mainui" ))
-		Localize_AddToDictionary( "mainui", language );
 
 	// if gamedir is czero, also load cstrike strings
 	if ( strcmp( gamedir, "czero" ) == 0 )

--- a/game_shared/voice_status_hud.cpp
+++ b/game_shared/voice_status_hud.cpp
@@ -102,6 +102,16 @@ void CVoiceLabel::SetLocation( const char *location )
 			RebuildLabelText();
 		}
 	}
+	else if ( location[0] == '#' )
+	{
+		// if the location is not localized and starts with #, clear the location
+		if ( m_locationString )
+		{
+			delete[] m_locationString;
+			m_locationString = NULL;
+			RebuildLabelText();
+		}
+	}
 	/*
 	else
 	{


### PR DESCRIPTION
Clear stale location name in the Voice HUD when the player moves to a location missing from the localization file.
Remove **mainui** and **gameui** localization files from the dictionary.