### PR TITLE
cl_dll: events: ev_cs16: remove unused sound

### DIFF
--- a/cl_dll/events/ev_cs16.cpp
+++ b/cl_dll/events/ev_cs16.cpp
@@ -260,7 +260,7 @@ void EV_HLDM_GunshotDecalTrace( pmtrace_t *pTrace, char *decalName, char chTextu
 		}
 		else
 		{
-			switch( iRand % 7)
+			switch( iRand % 6)
 			{
 			case 0:	gEngfuncs.pEventAPI->EV_PlaySound( -1, pTrace->endpos, 0, "weapons/ric1.wav", 1.0, ATTN_NORM, 0, PITCH_NORM ); break;
 			case 1:	gEngfuncs.pEventAPI->EV_PlaySound( -1, pTrace->endpos, 0, "weapons/ric2.wav", 1.0, ATTN_NORM, 0, PITCH_NORM ); break;
@@ -268,7 +268,6 @@ void EV_HLDM_GunshotDecalTrace( pmtrace_t *pTrace, char *decalName, char chTextu
 			case 3:	gEngfuncs.pEventAPI->EV_PlaySound( -1, pTrace->endpos, 0, "weapons/ric4.wav", 1.0, ATTN_NORM, 0, PITCH_NORM ); break;
 			case 4:	gEngfuncs.pEventAPI->EV_PlaySound( -1, pTrace->endpos, 0, "weapons/ric5.wav", 1.0, ATTN_NORM, 0, PITCH_NORM ); break;
 			case 5: gEngfuncs.pEventAPI->EV_PlaySound( -1, pTrace->endpos, 0, "weapons/ric_conc-1.wav", 1.0f, ATTN_NORM, 0, PITCH_NORM); break;
-			case 6: gEngfuncs.pEventAPI->EV_PlaySound( -1, pTrace->endpos, 0, "weapons/ric_conc-2.wav", 1.0f, ATTN_NORM, 0, PITCH_NORM); break;
 			}
 		}
 


### PR DESCRIPTION
When playing `Counter-Strike 1.6` on `Steam`, the sound `weapons/ric_conc-2.wav` does not exist. Since it is present in `CS16Client`, it may cause inconsistencies when playing on competitive servers.

https://github.com/Velaron/cs16-client/issues/323