### PR TITLE
fixed ugly smoke

### DIFF
--- a/cl_dll/events/event_createsmoke.cpp
+++ b/cl_dll/events/event_createsmoke.cpp
@@ -75,7 +75,7 @@ void EV_CreateSmoke(event_args_s *args)
 				pTemp->entity.curstate.fuser4 = gEngfuncs.GetClientTime(); // entity creation time
 
 				pTemp->entity.curstate.renderamt = 255;
-				pTemp->entity.curstate.rendermode = kRenderTransTexture;
+				pTemp->entity.curstate.rendermode = kRenderTransAlpha;
 				pTemp->entity.curstate.rendercolor.r = Com_RandomLong(210, 230);
 				pTemp->entity.curstate.rendercolor.g = Com_RandomLong(210, 230);
 				pTemp->entity.curstate.rendercolor.b = Com_RandomLong(210, 230);


### PR DESCRIPTION
when using kRenderTransTexture the smoke grenade renders above the viewmodel and looks ugly overall.

without this patch:
(notice  how you can see the edge of the texture)
<img width="1920" height="1200" alt="ss-06-05-2026_003" src="https://github.com/user-attachments/assets/afc1e429-e33c-44ba-95c4-7bbe6b33024d" />
also notice how when inside the smoke, the smoke puffs render above the viewmodel (you can see it blink when moving):
<img width="1920" height="1200" alt="ss-06-05-2026_008" src="https://github.com/user-attachments/assets/771105de-0d6c-48eb-8b52-da10e20cb875" />


with this patch:
<img width="1920" height="1200" alt="ss-06-05-2026_002" src="https://github.com/user-attachments/assets/1c5b0194-91c8-4cf3-8aa8-a3120bfca248" />
when inside the smoke:
<img width="1920" height="1200" alt="ss-06-05-2026_009" src="https://github.com/user-attachments/assets/7bfd0f9b-3665-4365-8931-2cac176c58e9" />

