### PR TITLE
client: add cvar to enable old touch menus

### DIFF
--- a/cl_dll/cdll_int.cpp
+++ b/cl_dll/cdll_int.cpp
@@ -83,6 +83,9 @@ int DLLEXPORT Initialize( cl_enginefunc_t *pEnginefuncs, int iVersion )
 
 	gEngfuncs = *pEnginefuncs;
 
+	// Register cvar to allow using old touch menus (1 = use old cfg-based menus)
+	CVAR_CREATE("cl_oldtouchmenus", "0", FCVAR_CLIENTDLL | FCVAR_ARCHIVE);
+
 	sscanf( CVAR_GET_STRING( "host_ver" ), "%d", &g_iXash );
 
 	Game_HookEvents();

--- a/cl_dll/cl_util.h
+++ b/cl_dll/cl_util.h
@@ -116,6 +116,12 @@ inline void CenterPrint( const char *string )
 	gEngfuncs.pfnCenterPrint( string );
 }
 
+// Returns true when client should use old cfg-based touch menus
+inline bool UseOldTouchMenusEnabled()
+{
+	return CVAR_GET_FLOAT("cl_oldtouchmenus") != 0.0f;
+}
+
 // returns the players name of entity no.
 #define GetPlayerInfo (*gEngfuncs.pfnGetPlayerInfo)
 

--- a/cl_dll/menu.cpp
+++ b/cl_dll/menu.cpp
@@ -279,7 +279,7 @@ void CHudMenu::ShowVGUIMenu( int menuType )
 	int team = g_PlayerExtraInfo[gHUD.m_Scoreboard.m_iPlayerNum].teamnumber;
 	int haveCancel = team != TEAM_UNASSIGNED ? 1 : 0;
 
-	if( g_pMenu )
+	if( g_pMenu && !UseOldTouchMenusEnabled() )
 	{
 		switch( menuType )
 		{


### PR DESCRIPTION
For compatibility with custom menus that use the old method of creating menus with touch buttons. A temporary solution until customization support for MainUI menus is implemented without hardcoding.