### PR TITLE
client: try to fix smoke not visible on first round

### DIFF
--- a/cl_dll/events/ev_cs16.cpp
+++ b/cl_dll/events/ev_cs16.cpp
@@ -704,7 +704,7 @@ void EV_HLDM_FireBullets(int idx,
 
 void EV_CS16Client_KillEveryRound( TEMPENTITY *te, float frametime, float current_time )
 {
-	if( !g_flRoundTime && current_time > g_flRoundTime )
+	if( g_flRoundTime > 0.0f && te->entity.curstate.fuser4 < g_flRoundTime )
 	{
 		// Mark it die on next TempEntUpdate
 		te->die = 0.0f;


### PR DESCRIPTION
`g_flRoundTime` is 0 on first round. `fuser4` stores entity creation time. When `g_flRoundTime` inevitably goes forward, entities created before it will get automatically cleaned in this function.

Could be also used for dead bodies, instead of storing them in array, which I think was intended at some point, judging by commented out `fuser4` assignment.

cc @Vladislav4KZ 