### PR TITLE
cl_dll: ammo: fix WeaponList sprite not showing when FOV is at default

### DIFF
--- a/cl_dll/ammo.cpp
+++ b/cl_dll/ammo.cpp
@@ -1052,6 +1052,9 @@ int CHudAmmo::Draw(float flTime)
 	if (!(gHUD.m_iWeaponBits & (1<<(WEAPON_SUIT)) ))
 		return 1;
 
+	if( gHUD.m_iHideHUDDisplay & ( HIDEHUD_WEAPONS | HIDEHUD_ALL ) )
+		return 1;
+
 	// place it here, so pretty dynamic crosshair will work even in spectator!
 	if( gHUD.m_iFOV > 40 )
 	{
@@ -1070,9 +1073,6 @@ int CHudAmmo::Draw(float flTime)
 			DrawSpriteCrosshair();
 		}
 	}
-
-	if ( (gHUD.m_iHideHUDDisplay & ( HIDEHUD_WEAPONS | HIDEHUD_ALL )) )
-		return 1;
 
 	// Draw Weapon Menu
 	DrawWList(flTime);

--- a/cl_dll/ammo.cpp
+++ b/cl_dll/ammo.cpp
@@ -1051,7 +1051,9 @@ int CHudAmmo::Draw(float flTime)
 	if( gHUD.m_iFOV > 40 )
 	{
 		// draw a dynamic crosshair
-		DrawCrosshair();
+		if( !( gHUD.m_iHideHUDDisplay & HIDEHUD_CROSSHAIR ) )
+			DrawCrosshair();
+
 		DrawSpriteCrosshair();
 	}
 	else

--- a/cl_dll/ammo.cpp
+++ b/cl_dll/ammo.cpp
@@ -631,6 +631,11 @@ int CHudAmmo::MsgFunc_CurWeapon(const char *pszName, int iSize, void *pbuf )
 
 	if( gHUD.m_iFOV >= 90 )
 	{ // normal crosshairs
+		if( fOnTarget && m_pWeapon->hAutoaim )
+			SetCrosshair( m_pWeapon->hAutoaim, m_pWeapon->rcAutoaim, 255, 255, 255 );
+		else
+			SetCrosshair( m_pWeapon->hCrosshair, m_pWeapon->rcCrosshair, 255, 255, 255 );
+
 		HideCrosshair(); // hide static
 	}
 	else

--- a/cl_dll/ammo.cpp
+++ b/cl_dll/ammo.cpp
@@ -1049,12 +1049,6 @@ int CHudAmmo::Draw(float flTime)
 	int a, x, y, r, g, b;
 	int AmmoWidth;
 
-	if (!(gHUD.m_iWeaponBits & (1<<(WEAPON_SUIT)) ))
-		return 1;
-
-	if( gHUD.m_iHideHUDDisplay & ( HIDEHUD_WEAPONS | HIDEHUD_ALL ) )
-		return 1;
-
 	// place it here, so pretty dynamic crosshair will work even in spectator!
 	if( gHUD.m_iFOV > 40 )
 	{
@@ -1073,6 +1067,12 @@ int CHudAmmo::Draw(float flTime)
 			DrawSpriteCrosshair();
 		}
 	}
+
+	if (!(gHUD.m_iWeaponBits & (1<<(WEAPON_SUIT)) ))
+		return 1;
+
+	if( gHUD.m_iHideHUDDisplay & ( HIDEHUD_WEAPONS | HIDEHUD_ALL ) )
+		return 1;
 
 	// Draw Weapon Menu
 	DrawWList(flTime);
@@ -1602,6 +1602,9 @@ void CHudAmmo::DrawCrosshair( int weaponId )
 
 void CHudAmmo::DrawCrosshair()
 {
+	if( g_iUser1 && g_iUser1 != OBS_IN_EYE )
+		return;
+
 	int flags, iDeltaDistance, iDistance, iLength, weaponid;
 	float flCrosshairDistance;
 

--- a/cl_dll/ammo.cpp
+++ b/cl_dll/ammo.cpp
@@ -565,7 +565,7 @@ int CHudAmmo::MsgFunc_HideWeapon( const char *pszName, int iSize, void *pbuf )
 	if (gEngfuncs.IsSpectateOnly())
 		return 1;
 
-	if ( gHUD.m_iHideHUDDisplay & ( HIDEHUD_WEAPONS | HIDEHUD_FLASHLIGHT | HIDEHUD_ALL ) )
+	if ( gHUD.m_iHideHUDDisplay & ( HIDEHUD_WEAPONS | HIDEHUD_FLASHLIGHT | HIDEHUD_ALL | HIDEHUD_CROSSHAIR ) )
 	{
 		gpActiveSel = NULL;
 		HideCrosshair();
@@ -581,11 +581,19 @@ int CHudAmmo::MsgFunc_HideWeapon( const char *pszName, int iSize, void *pbuf )
 //
 int CHudAmmo::MsgFunc_CurWeapon(const char *pszName, int iSize, void *pbuf )
 {
+	int fOnTarget = FALSE;
+
 	BufferReader reader( pszName, pbuf, iSize );
 
 	int iState = reader.ReadByte();
 	int iId = reader.ReadChar();
 	int iClip = reader.ReadChar();
+
+	// detect if we're also on target
+	if( iState > 1 )
+	{
+		fOnTarget = TRUE;
+	}
 
 	if ( iId < 1 )
 	{
@@ -620,6 +628,18 @@ int CHudAmmo::MsgFunc_CurWeapon(const char *pszName, int iSize, void *pbuf )
 		return 1;
 
 	m_pWeapon = pWeapon;
+
+	if( gHUD.m_iFOV >= 90 )
+	{ // normal crosshairs
+		HideCrosshair(); // hide static
+	}
+	else
+	{ // zoomed crosshairs
+		if( fOnTarget && m_pWeapon->hZoomedAutoaim )
+			SetCrosshair( m_pWeapon->hZoomedAutoaim, m_pWeapon->rcZoomedAutoaim, 255, 255, 255 );
+		else
+			SetCrosshair( m_pWeapon->hZoomedCrosshair, m_pWeapon->rcZoomedCrosshair, 255, 255, 255 );
+	}
 
 	m_fFade = 200.0f; //!!!
 
@@ -1030,10 +1050,9 @@ int CHudAmmo::Draw(float flTime)
 	// place it here, so pretty dynamic crosshair will work even in spectator!
 	if( gHUD.m_iFOV > 40 )
 	{
-		HideCrosshair(); // hide static
-
 		// draw a dynamic crosshair
 		DrawCrosshair();
+		DrawSpriteCrosshair();
 	}
 	else
 	{


### PR DESCRIPTION
`Draw()` was unconditionally calling `HideCrosshair()` whenever `FOV > 40`, wiping any sprite previously set via `WeaponList` + `CurWeapon`. At the same time, `MsgFunc_CurWeapon` was not managing the static sprite state, leaving `m_hStaticSpr` set with stale data during normal gameplay.

As a result, custom HUD sprites registered through this message pair were only visible when the player's FOV dropped to <= 40 (e.g. during AWP zoom), since that was the only path where `HideCrosshair()` was not called.

Additionally, `MsgFunc_HideWeapon` was not handling `HIDEHUD_CROSSHAIR`, so sending `HideWeapon` with that flag had no effect on the crosshair. The dynamic crosshair in `Draw()` was also not checking `HIDEHUD_CROSSHAIR`, leaving it visible when it should have been hidden.

https://github.com/Velaron/cs16-client/issues/339