### PR TITLE
cl_dll: extend health and money display limits

### DIFF
--- a/cl_dll/health.cpp
+++ b/cl_dll/health.cpp
@@ -294,7 +294,7 @@ void CHudHealth::DrawHealthBar( float flTime )
 		if( idx >= 1 && idx <= MAX_PLAYERS && g_PlayerExtraInfo[idx].sb_health > 255 )
 			x = DrawUtils::DrawHudNumber2( x, y, g_PlayerExtraInfo[idx].sb_health, r, g, b );
 		else
-			x = DrawUtils::DrawHudNumber(x, y, DHN_3DIGITS | DHN_DRAWZERO, m_iHealth, r, g, b);
+			x = DrawUtils::DrawHudNumber( x, y, DHN_3DIGITS | DHN_DRAWZERO, m_iHealth, r, g, b );
 	}
 }
 

--- a/cl_dll/health.cpp
+++ b/cl_dll/health.cpp
@@ -289,7 +289,12 @@ void CHudHealth::DrawHealthBar( float flTime )
 
 		x = CrossWidth + HealthWidth / 2;
 
-		x = DrawUtils::DrawHudNumber(x, y, DHN_3DIGITS | DHN_DRAWZERO, m_iHealth, r, g, b);
+		int idx = gEngfuncs.GetLocalPlayer()->index;
+
+		if( idx >= 1 && idx <= MAX_PLAYERS && g_PlayerExtraInfo[idx].sb_health > 255 )
+			x = DrawUtils::DrawHudNumber2( x, y, g_PlayerExtraInfo[idx].sb_health, r, g, b );
+		else
+			x = DrawUtils::DrawHudNumber(x, y, DHN_3DIGITS | DHN_DRAWZERO, m_iHealth, r, g, b);
 	}
 }
 

--- a/cl_dll/hud/scoreboard.cpp
+++ b/cl_dll/hud/scoreboard.cpp
@@ -213,10 +213,10 @@ int CHudScoreboard :: DrawScoreboard( float fTime )
 	g_Columns[COL_KILLS].end = min( g_Columns[COL_KILLS].end, g_Columns[COL_KILLS].start - DrawUtils::HudStringLen( "9999" ) );
 
 	g_Columns[COL_MONEY] = Column( g_Columns[COL_KILLS].end - 10, Localize( "#Cstrike_ACCOUNT" ) );
-	g_Columns[COL_MONEY].end = min( g_Columns[COL_MONEY].end, g_Columns[COL_MONEY].start - DrawUtils::HudStringLen( "$16000" ) );
+	g_Columns[COL_MONEY].end = min( g_Columns[COL_MONEY].end, g_Columns[COL_MONEY].start - DrawUtils::HudStringLen( "$999999" ) );
 
 	g_Columns[COL_HP] = Column( g_Columns[COL_MONEY].end - 10, Localize( "#Cstrike_HEALTH" ) );
-	g_Columns[COL_HP].end = min( g_Columns[COL_HP].end, g_Columns[COL_HP].start - DrawUtils::HudStringLen( "100" ) );
+	g_Columns[COL_HP].end = min( g_Columns[COL_HP].end, g_Columns[COL_HP].start - DrawUtils::HudStringLen( "999999" ) );
 
 	g_Columns[COL_ATTRIB] = Column( g_Columns[COL_HP].end - 10 );
 	g_Columns[COL_ATTRIB].end = g_Columns[COL_ATTRIB].start - DrawUtils::HudStringLen( "#Cstrike_DEFUSE_KIT" );

--- a/cl_dll/hud/spectator_gui.cpp
+++ b/cl_dll/hud/spectator_gui.cpp
@@ -422,8 +422,10 @@ void CHudSpectatorGui::CalcAllNeededData( )
 		hud_player_info_t sInfo;
 		GetPlayerInfo( g_iUser2, &sInfo );
 
+		int iHealth = g_PlayerExtraInfo[g_iUser2].sb_health > 255 ? g_PlayerExtraInfo[g_iUser2].sb_health : g_PlayerExtraInfo[g_iUser2].health;
+
 		snprintf( label.m_szNameAndHealth, sizeof( label.m_szNameAndHealth ),
-				  "%s (%i)",  sInfo.name, g_PlayerExtraInfo[g_iUser2].health );
+				  "%s (%i)",  sInfo.name, iHealth );
 	}
 	else label.m_szNameAndHealth[0] = '\0';
 }


### PR DESCRIPTION
https://github.com/Velaron/cs16-client/issues/349

`cl_dll/health.cpp`
- Use `DrawHudNumber2` when `sb_health > 255` to render the actual value, falls back to `m_iHealth` otherwise.

<img alt="image" src="https://github.com/user-attachments/assets/458e02f0-749b-4455-8785-6843b2479a1f" />

`cl_dll/hud/scoreboard`
- Widen `COL_HP` column to fit up to 6 digits (`999999`).
- Widen `COL_MONEY` column to fit up to `$999999`, the maximum enforced by `ReGameDLL`. (https://github.com/rehlds/ReGameDLL_CS/blob/master/dist/game.cfg#L26)

`cl_dll/spectator_gui.cpp`
- Use `sb_health` when `> 255` to display the correct health in the spectator overlay, falls back to `health` otherwise.

<img alt="image" src="https://github.com/user-attachments/assets/cbd7e4c3-b1d6-4983-91ab-f81a8dbfba47" />