### PR TITLE
cl_dll: hud: timer: fix Draw

### DIFF
--- a/cl_dll/hud/timer.cpp
+++ b/cl_dll/hud/timer.cpp
@@ -55,7 +55,7 @@ int CHudTimer::VidInit()
 
 int CHudTimer::Draw( float fTime )
 {
-	if ( ( gHUD.m_iHideHUDDisplay & HIDEHUD_HEALTH ) )
+	if ( ( gHUD.m_iHideHUDDisplay & HIDEHUD_TIMER ) )
 		return 1;
 
 	if (!(gHUD.m_iWeaponBits & (1<<(WEAPON_SUIT)) ))

--- a/cl_dll/hud/timer.cpp
+++ b/cl_dll/hud/timer.cpp
@@ -55,7 +55,7 @@ int CHudTimer::VidInit()
 
 int CHudTimer::Draw( float fTime )
 {
-	if ( ( gHUD.m_iHideHUDDisplay & HIDEHUD_TIMER ) )
+	if( gHUD.m_iHideHUDDisplay & ( HIDEHUD_TIMER | HIDEHUD_ALL ) )
 		return 1;
 
 	if (!(gHUD.m_iWeaponBits & (1<<(WEAPON_SUIT)) ))


### PR DESCRIPTION
`CHudTimer::Draw` was checking `HIDEHUD_HEALTH` instead of `HIDEHUD_TIMER`, also missing `HIDEHUD_ALL` check.