### PR TITLE
cl_dll: hud: money: fix Draw

### DIFF
--- a/cl_dll/hud/money.cpp
+++ b/cl_dll/hud/money.cpp
@@ -60,7 +60,7 @@ int CHudMoney::VidInit()
 
 int CHudMoney::Draw(float flTime)
 {
-	if(( gHUD.m_iHideHUDDisplay & ( HIDEHUD_HEALTH ) ))
+	if( gHUD.m_iHideHUDDisplay & ( HIDEHUD_MONEY | HIDEHUD_ALL ) )
 		return 1;
 
 	if (!(gHUD.m_iWeaponBits & (1<<(WEAPON_SUIT))))


### PR DESCRIPTION
`CHudMoney::Draw` was checking `HIDEHUD_HEALTH` instead of `HIDEHUD_MONEY`, also missing `HIDEHUD_ALL` check.