### PR TITLE
cl_dll: hud: money, timer: fix Draw when spectating in first person

### DIFF
--- a/cl_dll/hud/money.cpp
+++ b/cl_dll/hud/money.cpp
@@ -38,6 +38,7 @@ version.
 #include <string.h>
 #include "vgui_parser.h"
 #include "draw_util.h"
+#include "pm_shared.h"
 
 int CHudMoney::Init( )
 {

--- a/cl_dll/hud/money.cpp
+++ b/cl_dll/hud/money.cpp
@@ -66,6 +66,9 @@ int CHudMoney::Draw(float flTime)
 	if (!(gHUD.m_iWeaponBits & (1<<(WEAPON_SUIT))))
 		return 1;
 
+	if( g_iUser1 == OBS_IN_EYE )
+		return 1;
+
 	int r, g, b, alphaBalance;
 	m_fFade -= gHUD.m_flTimeDelta;
 	if( m_fFade < 0)

--- a/cl_dll/hud/timer.cpp
+++ b/cl_dll/hud/timer.cpp
@@ -36,6 +36,7 @@ version.
 #include "vgui_parser.h"
 #include <string.h>
 #include "draw_util.h"
+#include "pm_shared.h"
 
 int CHudTimer::Init()
 {

--- a/cl_dll/hud/timer.cpp
+++ b/cl_dll/hud/timer.cpp
@@ -60,6 +60,10 @@ int CHudTimer::Draw( float fTime )
 
 	if (!(gHUD.m_iWeaponBits & (1<<(WEAPON_SUIT)) ))
 		return 1;
+
+	if( g_iUser1 == OBS_IN_EYE )
+		return 1;
+
 	int r, g, b;
 	// time must be positive
 	int minutes = max( 0, (int)( m_iTime + m_fStartTime - gHUD.m_flTime ) / 60);


### PR DESCRIPTION
When spectating a player in first person (OBS_IN_EYE), the money and timer HUD elements remain visible, which should not happen.

Reference:

https://github.com/Velaron/cs16-client/blob/main/cl_dll/flashlight.cpp#L96-L97