### PR TITLE
cl_dll: environment: Fix MsgFunc_ReceiveW

### DIFF
--- a/cl_dll/environment.cpp
+++ b/cl_dll/environment.cpp
@@ -1601,6 +1601,14 @@ int CEnvironment::MsgFunc_ReceiveW(const char *pszName, int iSize, void *pbuf)
 
 	const int weatherType = reader.ReadByte();
 
+	if( weatherType == 0 )
+	{
+		m_iSavedWeatherType = 0;
+		RemoveRain(0);
+		RemoveSnow(0);
+		return 1;
+	}
+
 	if (weatherType < 1 || weatherType > 2)
 		return 1;
 


### PR DESCRIPTION
`MsgFunc_ReceiveW` returned early after hitting the validation guard when weather type `0` was sent, preventing the weather state from being cleared.

This validation was originally present in `rain.cpp` but was lost when the file was removed.

Reference:
https://github.com/Velaron/cs16-client/blob/0879a4673534c11100416148c5f8bc354fe25e40/cl_dll/rain.cpp#L475-L479