### PR TITLE
client: don't draw the sniper crosshair sprite in spectator modes other than first-person

### DIFF
--- a/cl_dll/ammo.cpp
+++ b/cl_dll/ammo.cpp
@@ -1173,6 +1173,9 @@ void CHudAmmo::DrawSpriteCrosshair()
 {
 	int x, y;
 
+	if( g_iUser1 && g_iUser1 != OBS_IN_EYE )
+		return;
+
 	if( !m_hStaticSpr )
 		return;
 


### PR DESCRIPTION
Fixes: https://github.com/Velaron/cs16-client/issues/386