### PR TITLE
ci: scripts: psvita: set VDPM_NONINTERACTIVE to fix vdpm confirmation hang

### DIFF
--- a/scripts/psvita_sdk.sh
+++ b/scripts/psvita_sdk.sh
@@ -4,17 +4,25 @@ cd $GITHUB_WORKSPACE
 
 export VITASDK=/usr/local/vitasdk
 
+# vdpm is a pacman frontend now, it asks for confirmation unless told otherwise
+export VDPM_NONINTERACTIVE=1
+
+install_package()
+{
+	./vdpm install "$1" || exit 1
+}
+
 echo "Downloading vitasdk..."
 git clone https://github.com/vitasdk/vdpm.git --depth=1 || exit 1
-pushd vdpm
+pushd vdpm || exit 1
 ./bootstrap-vitasdk.sh || exit 1
-./vdpm taihen || exit 1
-./vdpm kubridge || exit 1
-./vdpm zlib || exit 1
-./vdpm SceShaccCgExt || exit 1
-./vdpm vitaShaRK || exit 1
-./vdpm libmathneon || exit 1
-popd
+install_package taihen
+install_package kubridge
+install_package zlib
+install_package SceShaccCgExt
+install_package vitaShaRK
+install_package libmathneon
+popd || exit 1
 
 echo "Building vrtld..."
 git clone https://github.com/fgsfdsfgs/vita-rtld.git --depth=1 || exit 1


### PR DESCRIPTION
Used the upstream Xash3D FWGS [``deps_psvita.sh``](https://github.com/FWGS/xash3d-fwgs/blob/master/scripts/gha/deps_psvita.sh) script as a reference.
This should fix PS Vita builds in GitHub Actions.