### PR TITLE
client: input: fix cl_movespeedkey handling

### DIFF
--- a/cl_dll/input.cpp
+++ b/cl_dll/input.cpp
@@ -690,13 +690,8 @@ void DLLEXPORT CL_CreateMove ( float frametime, struct usercmd_s *cmd, int activ
 			}
 		}	
 
-		// adjust for speed key
-		if ( in_speed.state & 1 )
-		{
-			cmd->forwardmove *= cl_movespeedkey->value;
-			cmd->sidemove *= cl_movespeedkey->value;
-			cmd->upmove *= cl_movespeedkey->value;
-		}
+		// Allow mice and other controllers to add their inputs
+		IN_Move ( frametime, cmd );
 
 		// clip to maxspeed
 		spd = gEngfuncs.GetClientMaxspeed();
@@ -714,8 +709,17 @@ void DLLEXPORT CL_CreateMove ( float frametime, struct usercmd_s *cmd, int activ
 			}
 		}
 
-		// Allow mice and other controllers to add their inputs
-		IN_Move ( frametime, cmd );
+		// adjust for speed key
+		if ( in_speed.state & 1 )
+		{
+			float speed = cl_movespeedkey->value;
+			if ( speed > 0.52f )
+				speed = 0.52f;
+
+			cmd->forwardmove *= speed;
+			cmd->sidemove *= speed;
+			cmd->upmove *= speed;
+		}
 	}
 
 	cmd->impulse = in_impulse;

--- a/cl_dll/input/input_xash3d.cpp
+++ b/cl_dll/input/input_xash3d.cpp
@@ -209,11 +209,6 @@ void IN_Move( float frametime, usercmd_t *cmd )
 		IN_ToggleButtons( ac_forwardmove / ac_movecount, ac_sidemove / ac_movecount );
 		if( ac_forwardmove ) cmd->forwardmove  = ac_forwardmove * cl_forwardspeed->value / ac_movecount;
 		if( ac_sidemove ) cmd->sidemove  = ac_sidemove * cl_sidespeed->value / ac_movecount;
-		if (in_speed.state & 1)
-		{
-			cmd->forwardmove *= cl_movespeedkey->value;
-			cmd->sidemove *= cl_movespeedkey->value;
-		}
 	}
 	
 	ac_sidemove = ac_forwardmove = rel_pitch = rel_yaw = 0;


### PR DESCRIPTION
Fixes: https://github.com/Velaron/cs16-client/issues/109

Match the original CS 1.6 client behavior by moving ``IN_Move`` before the maxspeed clamp, applying ``cl_movespeedkey`` after the clamp, and capping the multiplier at ``0.52``.

Remove the additional ``cl_movespeedkey`` multiplication from ``IN_Move`` to avoid applying the multiplier twice.

Pseudocode from the original Steam version of CS 1.6, decompiled from ``client.so`` using IDA Pro
```
IN_Move(frametime, cmd);
v48 = gEngfuncs.GetClientMaxspeed();
if ( v48 != 0.0 )
{
  v64 = sqrt(cmd->forwardmove * cmd->forwardmove + cmd->sidemove * cmd->sidemove + cmd->upmove * cmd->upmove);
  if ( v64 > v48 )
  {
	v65 = v48 / v64;
	cmd->forwardmove = cmd->forwardmove * v65;
	cmd->sidemove = cmd->sidemove * v65;
	cmd->upmove = v65 * cmd->upmove;
  }
}
if ( (in_speed.state & 1) != 0 )
{
  v49 = cl_movespeedkey->value;
  if ( v49 > 0.51999998 )
	v49 = 0.51999998;
  cmd->forwardmove = cmd->forwardmove * v49;
  cmd->sidemove = cmd->sidemove * v49;
  cmd->upmove = v49 * cmd->upmove;
}
 ```