### PR TITLE
client: hud: don't overwrite teamnumber in ScoreInfo

### DIFF
--- a/cl_dll/hud/scoreboard.cpp
+++ b/cl_dll/hud/scoreboard.cpp
@@ -569,14 +569,13 @@ int CHudScoreboard :: MsgFunc_ScoreInfo( const char *pszName, int iSize, void *p
 	short frags = reader.ReadShort();
 	short deaths = reader.ReadShort();
 	short playerclass = reader.ReadShort();
-	short teamnumber = reader.ReadShort();
+	reader.ReadShort();
 
 	if ( cl > 0 && cl <= MAX_PLAYERS )
 	{
 		g_PlayerExtraInfo[cl].frags = frags;
 		g_PlayerExtraInfo[cl].deaths = deaths;
 		g_PlayerExtraInfo[cl].playerclass = playerclass;
-		g_PlayerExtraInfo[cl].teamnumber = teamnumber;
 
 		//gViewPort->UpdateOnPlayerInfo();
 	}


### PR DESCRIPTION
Possible fix for: https://github.com/Velaron/cs16-client/issues/402

The original CS 1.6 client does not overwrite ``teamnumber`` in ``MsgFunc_ScoreInfo``. See the pseudocode from the decompilation of the original Steam ``client.so``, specifically the ``CounterStrikeViewport::MsgFunc_ScoreInfo`` function:
```
BEGIN_READ(pbuf, iSize);
v4 = READ_BYTE();
v5 = READ_SHORT();
v6 = READ_SHORT();
playerclass = READ_SHORT();
READ_SHORT(); // <-- the team number is read here, but it is not assigned to teamnumber
if ( (unsigned __int16)(v4 - 1) > 0x3Fu )
return 1;
v7 = v4;
v8 = g_PlayerExtraInfo[v7].teamnumber >= 0;
g_PlayerExtraInfo[v7].frags = v5;
g_PlayerExtraInfo[v7].deaths = v6;
g_PlayerExtraInfo[v7].playerclass = playerclass;
```