### PR TITLE
client: fix GetGunPosition not properly set for non-local player

### DIFF
--- a/cl_dll/ev_common.cpp
+++ b/cl_dll/ev_common.cpp
@@ -104,7 +104,7 @@ Figure out the height of the gun
 void EV_GetGunPosition( event_args_t *args, Vector &pos, const Vector &origin )
 {
 	int idx;
-	Vector view_ofs(0, 0, 0);
+	Vector view_ofs( 0, 0, DEFAULT_VIEWHEIGHT );
 
 	idx = args->entindex;
 
@@ -120,10 +120,6 @@ void EV_GetGunPosition( event_args_t *args, Vector &pos, const Vector &origin )
 		{
 			view_ofs[2] = VEC_DUCK_VIEW;
 		}
-	}
-	else
-	{
-		view_ofs[2] = DEFAULT_VIEWHEIGHT;
 	}
 
 	pos = origin + view_ofs;


### PR DESCRIPTION
This fix other player bullet effect slightly lower height than it should be.
Most noticeable when spectating a player firing a weapon when standing.
