### PR TITLE
Use vid_width and vid_height to fix sniperscope hud

### DIFF
--- a/cl_dll/ammo.cpp
+++ b/cl_dll/ammo.cpp
@@ -1196,14 +1196,6 @@ void CHudAmmo::DrawSpriteCrosshair()
 #define SOUTH_YPOS (ScreenHeight / 2 + flCrosshairDistance)
 #define NORTH_SOUTH_XPOS (ScreenWidth / 2)
 
-#define WEST_XPOS_R (TrueWidth / 2 - flCrosshairDistance - iLength + 1)
-#define EAST_XPOS_R (flCrosshairDistance + TrueWidth / 2)
-#define EAST_WEST_YPOS_R (TrueHeight / 2)
-
-#define NORTH_YPOS_R (TrueHeight / 2 - flCrosshairDistance - iLength + 1)
-#define SOUTH_YPOS_R (TrueHeight / 2 + flCrosshairDistance)
-#define NORTH_SOUTH_XPOS_R (TrueWidth / 2)
-
 int Distances[30][2] =
 {
 { 8, 3 }, // 0

--- a/cl_dll/hud.cpp
+++ b/cl_dll/hud.cpp
@@ -459,8 +459,8 @@ void CHud :: VidInit( void )
 	m_scrinfo.iSize = sizeof( m_scrinfo );
 	GetScreenInfo( &m_scrinfo );
 
-	m_truescrinfo.iWidth = CVAR_GET_FLOAT("width");
-	m_truescrinfo.iHeight = CVAR_GET_FLOAT("height");
+	m_truescrinfo.iWidth = CVAR_GET_FLOAT("vid_width");
+	m_truescrinfo.iHeight = CVAR_GET_FLOAT("vid_height");
 
 	// ----------
 	// Load Sprites


### PR DESCRIPTION
This seems to resolve the issue with the sniperscope.

Some defines that depend on `TrueWidth` and `TrueHeight` were removed along the way since they're not used anymore.